### PR TITLE
[v2.3.0] Integrated core bach ClojureScript library

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,29 @@
 
 You can find detailed information on the `bach` notation by visiting the [repository home page](https://github.com/slurmulon/bach).
 
-This library parses [bach.json](https://github.com/slurmulon/bach-json-schema) data and establishes the semantics.
+This library parses `bach` into [bach.json](https://github.com/slurmulon/bach-json-schema) data and establishes the semantics.
+
+It also provides a collection of common data transformation and utility methods that make working with `bach.json` even easier.
 
 It is not ready for production and should be considered experimental.
+
+## Install
+
+```sh
+npm i slurmulon/bach-js
+```
+
+## Usage
+
+```js
+import { Track } from 'bach-js'
+
+const track = new Track("@Tempo = 78 !Play [1 -> { Scale('B mixolydian') Chord('B') } 1 -> Chord('A')]")
+
+console.log(track.headers)
+console.log(track.data)
+```
+
+## License
+
+MIT

--- a/dist/bundle.js
+++ b/dist/bundle.js
@@ -547,6 +547,7 @@ var Track = function () {
   function Track(source) {
     classCallCheck(this, Track);
 
+    this.origin = source;
     this.source = compose(source);
   }
 

--- a/dist/bundle.js
+++ b/dist/bundle.js
@@ -5,6 +5,7 @@ Object.defineProperty(exports, '__esModule', { value: true });
 function _interopDefault (ex) { return (ex && (typeof ex === 'object') && 'default' in ex) ? ex['default'] : ex; }
 
 var teoria$1 = require('teoria');
+var bach = _interopDefault(require('bach-cljs'));
 var schema = _interopDefault(require('bach-json-schema'));
 var Ajv = _interopDefault(require('ajv'));
 
@@ -222,20 +223,34 @@ ajv.addMetaSchema(require('ajv/lib/refs/json-schema-draft-06.json'));
 
 var validate = ajv.compile(schema);
 
-var valid = function valid(bach) {
-  if (!validate(bach)) {
+var valid = function valid(bach$$1) {
+  if (!validate(bach$$1)) {
     var message = 'Invalid Bach.JSON source data';
     var pretty = function pretty(json) {
       return JSON.stringify(json, null, 2);
     };
 
-    console.error(message, pretty(bach));
+    console.error(message, pretty(bach$$1));
     console.error(pretty(validate.errors));
 
     throw TypeError('Invalid Bach.JSON source data');
   }
 
-  return bach;
+  return bach$$1;
+};
+
+// Either "composes" raw bach data into bach.json or, when provided an object, validates its structure as bach.json.
+// Main entry point for integrating with core bach ClojureScript library.
+var compose = function compose(source) {
+  if (typeof source === 'string') {
+    return bach(source);
+  }
+
+  if ((typeof source === 'undefined' ? 'undefined' : _typeof(source)) === 'object') {
+    return valid(source);
+  }
+
+  throw TypeError('Unsupported Bach.JSON data type (' + (typeof source === 'undefined' ? 'undefined' : _typeof(source)) + '). Must be a bach.json object or raw bach string.');
 };
 
 // Creates Bach.JSON beat elements from minimal data.
@@ -250,15 +265,11 @@ var atomize = function atomize(kind, value) {
 // Consumes bach.json source data and parses/normalizes each beat.
 // Light-weight alternative to using Track constructor.
 var normalize = function normalize(source) {
-  if (validate(source)) {
-    return Object.assign({}, source, {
-      data: source.data.map(Beat.from)
-    });
-  }
+  var bach$$1 = compose(source);
 
-  console.error(validate.errors);
-
-  throw TypeError('Invalid Bach.JSON data');
+  return Object.assign({}, bach$$1, {
+    data: bach$$1.data.map(Beat.from)
+  });
 };
 
 // Converts a parsed Track's `data` back into its serialized form (vanilla bach.json).
@@ -536,7 +547,7 @@ var Track = function () {
   function Track(source) {
     classCallCheck(this, Track);
 
-    this.source = valid(source);
+    this.source = compose(source);
   }
 
   /**
@@ -664,7 +675,7 @@ var Sections = function () {
   function Sections(source) {
     classCallCheck(this, Sections);
 
-    this.source = normalize(valid(source));
+    this.source = normalize(source);
     this.data = sectionize(this.source);
   }
 
@@ -720,6 +731,7 @@ exports.Note = Note$1;
 exports.Sections = Sections;
 exports.validate = validate;
 exports.valid = valid;
+exports.compose = compose;
 exports.atomize = atomize;
 exports.normalize = normalize;
 exports.serialize = serialize;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bach-js",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -756,6 +756,31 @@
       "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
       "dev": true
     },
+    "bach-cljs": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bach-cljs/-/bach-cljs-1.0.3.tgz",
+      "integrity": "sha512-+gohXIyC25GbF91gvj1zgGpbNiWngAAftR6RaL8uOpJ/wprznanKZTuaY9AUvut5L8/H69lgL2a/N1ug5C3X1w==",
+      "requires": {
+        "google-closure-library": "^20210106.0.0",
+        "source-map-support": "^0.5.19"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        },
+        "source-map-support": {
+          "version": "0.5.19",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
+          "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
+          "requires": {
+            "buffer-from": "^1.0.0",
+            "source-map": "^0.6.0"
+          }
+        }
+      }
+    },
     "bach-json-schema": {
       "version": "github:slurmulon/bach-json-schema#13fc0a08847b6bf2fa4bd784d5447f188ef81d58",
       "from": "github:slurmulon/bach-json-schema"
@@ -954,6 +979,11 @@
       "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
       "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw=",
       "dev": true
+    },
+    "buffer-from": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
     },
     "bytes": {
       "version": "3.1.0",
@@ -1698,6 +1728,11 @@
       "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
       "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
       "dev": true
+    },
+    "google-closure-library": {
+      "version": "20210106.0.0",
+      "resolved": "https://registry.npmjs.org/google-closure-library/-/google-closure-library-20210106.0.0.tgz",
+      "integrity": "sha512-ONJTdzXvBZ8oQ3MscZxSmw2w1SWpIq1FI0dZQdJQQXrXRFXCsBmntj/IFGE+QTOynmOo6Ee1YTq6p2h8O3oQWA=="
     },
     "graceful-fs": {
       "version": "4.2.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -757,9 +757,9 @@
       "dev": true
     },
     "bach-cljs": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/bach-cljs/-/bach-cljs-1.0.3.tgz",
-      "integrity": "sha512-+gohXIyC25GbF91gvj1zgGpbNiWngAAftR6RaL8uOpJ/wprznanKZTuaY9AUvut5L8/H69lgL2a/N1ug5C3X1w==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/bach-cljs/-/bach-cljs-1.0.5.tgz",
+      "integrity": "sha512-E/O+TfHyy1iLTULs1qOzkyK+p4PnOFk9K0DUO2V4+hfNkpvIk/bUVFuBd2LrrDU+/J2c/WLII/BefqQUCLo3Hw==",
       "requires": {
         "google-closure-library": "^20210106.0.0",
         "source-map-support": "^0.5.19"

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@sinonjs/commons": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.1.tgz",
-      "integrity": "sha512-892K+kWUUi3cl+LlqEWIDrhvLgdL79tECi8JZUyq6IviKy/DNhuzCRlbHUjxK89f4ypPMMaFnFuR9Ie6DoIMsw==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.2.tgz",
+      "integrity": "sha512-sruwd86RJHdsVf/AtBoijDmUqJp3B6hF/DGC23C+JaegnDHaZyewCjoVGTdg3J0uz3Zs7NnIT05OBOmML72lQw==",
       "dev": true,
       "requires": {
         "type-detect": "4.0.8"
@@ -61,9 +61,9 @@
       "dev": true
     },
     "ajv": {
-      "version": "6.12.5",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.5.tgz",
-      "integrity": "sha512-lRF8RORchjpKG50/WFf8xmg7sgCLFiYNNnqdKflk63whMQcWR5ngGjiSXkL9bjxy6B2npOK2HSMN49jEBMSkag==",
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "requires": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -183,6 +183,14 @@
         "slash": "^1.0.0",
         "source-map": "^0.5.6",
         "v8flags": "^2.1.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
       }
     },
     "babel-code-frame": {
@@ -221,6 +229,14 @@
         "private": "^0.1.8",
         "slash": "^1.0.0",
         "source-map": "^0.5.7"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
       }
     },
     "babel-generator": {
@@ -237,6 +253,14 @@
         "lodash": "^4.17.4",
         "source-map": "^0.5.7",
         "trim-right": "^1.0.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
       }
     },
     "babel-helper-call-delegate": {
@@ -696,6 +720,23 @@
         "lodash": "^4.17.4",
         "mkdirp": "^0.5.1",
         "source-map-support": "^0.4.15"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        },
+        "source-map-support": {
+          "version": "0.4.18",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
+          "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
+          "dev": true,
+          "requires": {
+            "source-map": "^0.5.6"
+          }
+        }
       }
     },
     "babel-runtime": {
@@ -763,26 +804,10 @@
       "requires": {
         "google-closure-library": "^20210106.0.0",
         "source-map-support": "^0.5.19"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-        },
-        "source-map-support": {
-          "version": "0.5.19",
-          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
-          "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
-          "requires": {
-            "buffer-from": "^1.0.0",
-            "source-map": "^0.6.0"
-          }
-        }
       }
     },
     "bach-json-schema": {
-      "version": "github:slurmulon/bach-json-schema#13fc0a08847b6bf2fa4bd784d5447f188ef81d58",
+      "version": "github:slurmulon/bach-json-schema#37702f4ee81eb199f80ff0c75058a44aaa8046cb",
       "from": "github:slurmulon/bach-json-schema"
     },
     "backo2": {
@@ -1202,9 +1227,9 @@
       "dev": true
     },
     "core-js": {
-      "version": "2.6.11",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
-      "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==",
+      "version": "2.6.12",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
+      "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
       "dev": true
     },
     "core-util-is": {
@@ -1626,9 +1651,9 @@
       }
     },
     "follow-redirects": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.0.tgz",
-      "integrity": "sha512-aq6gF1BEKje4a9i9+5jimNFIpq4Q1WiwBToeRK5NvZBd/TRsmW8BsJfOEGkr76TbOyPVD3OVDN910EcUNtRYEA==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.2.tgz",
+      "integrity": "sha512-6mPTgLxYm3r6Bkkg0vNM0HTjfGrOEtsfbhagQvbxDEsEkpNhw582upBaoRZylzen6krEmxXJgt9Ju6HiI4O7BA==",
       "dev": true
     },
     "for-in": {
@@ -2189,6 +2214,12 @@
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
           "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
           "dev": true
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
         }
       }
     },
@@ -2414,18 +2445,18 @@
       "dev": true
     },
     "mime-db": {
-      "version": "1.44.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
-      "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==",
+      "version": "1.45.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.45.0.tgz",
+      "integrity": "sha512-CkqLUxUk15hofLoLyljJSrukZi8mAtgd+yE5uO4tqRZsdsAJKv0O+rFMhVDRJgozy+yG6md5KwuXhD4ocIoP+w==",
       "dev": true
     },
     "mime-types": {
-      "version": "2.1.27",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
-      "integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
+      "version": "2.1.28",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.28.tgz",
+      "integrity": "sha512-0TO2yJ5YHYr7M2zzT7gDU1tbwHxEUWBCLt0lscSNpcdAfFyJOVEpRYNS7EXVcTLNj/25QO8gulHC5JtTzSE2UQ==",
       "dev": true,
       "requires": {
-        "mime-db": "1.44.0"
+        "mime-db": "1.45.0"
       }
     },
     "minimatch": {
@@ -2558,9 +2589,9 @@
       "dev": true
     },
     "nan": {
-      "version": "2.14.1",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
-      "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==",
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
       "dev": true,
       "optional": true
     },
@@ -2875,9 +2906,9 @@
       }
     },
     "pathval": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
-      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
       "dev": true
     },
     "pitch-fq": {
@@ -3278,9 +3309,9 @@
       }
     },
     "regenerate": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.1.tgz",
-      "integrity": "sha512-j2+C8+NtXQgEKWk49MMP5P/u2GhnahTtVkRIHr5R5lVRlbKvmQ+oS+A5aLKWp2ma5VkT8sh6v+v4hbH0YHR66A==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
+      "integrity": "sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==",
       "dev": true
     },
     "regenerator-runtime": {
@@ -3420,6 +3451,23 @@
       "dev": true,
       "requires": {
         "source-map-support": "^0.4.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        },
+        "source-map-support": {
+          "version": "0.4.18",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
+          "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
+          "dev": true,
+          "requires": {
+            "source-map": "^0.5.6"
+          }
+        }
       }
     },
     "rollup-plugin-babel": {
@@ -3618,6 +3666,12 @@
           "requires": {
             "is-extendable": "^0.1.0"
           }
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
         }
       }
     },
@@ -3842,10 +3896,9 @@
       }
     },
     "source-map": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-      "dev": true
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
     },
     "source-map-resolve": {
       "version": "0.5.3",
@@ -3861,18 +3914,18 @@
       }
     },
     "source-map-support": {
-      "version": "0.4.18",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
-      "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
-      "dev": true,
+      "version": "0.5.19",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
+      "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
       "requires": {
-        "source-map": "^0.5.6"
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
       }
     },
     "source-map-url": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
-      "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.1.tgz",
+      "integrity": "sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw==",
       "dev": true
     },
     "split-string": {
@@ -4109,9 +4162,9 @@
       }
     },
     "uri-js": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.0.tgz",
-      "integrity": "sha512-B0yRTzYdUCCn9n+F4+Gh4yIDtMQcaJsmYBDsTSG8g/OejKBodLQ2IHfN3bM7jUsRXndopT7OIXWdYqc1fjmV6g==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "requires": {
         "punycode": "^2.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bach-js",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "Bach music notation parser for JS",
   "main": "dist/bundle.js",
   "scripts": {
@@ -27,6 +27,7 @@
   "homepage": "https://github.com/slurmulon/bach-js#readme",
   "dependencies": {
     "ajv": "^6.4.0",
+    "bach-cljs": "1.0.3",
     "bach-json-schema": "github:slurmulon/bach-json-schema",
     "teoria": "^2.5.0"
   },

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "homepage": "https://github.com/slurmulon/bach-js#readme",
   "dependencies": {
     "ajv": "^6.4.0",
-    "bach-cljs": "1.0.3",
+    "bach-cljs": "1.0.5",
     "bach-json-schema": "github:slurmulon/bach-json-schema",
     "teoria": "^2.5.0"
   },

--- a/src/data.js
+++ b/src/data.js
@@ -1,12 +1,27 @@
+import bach from 'bach-cljs'
 import { Beat } from './elements'
 import { Note } from './note'
-import validate from './validate'
+import { valid } from './validate'
 import {
   scale as teoriaScale,
   chord as teoriaChord,
   Scale as TeoriaScale,
   Chord as TeoriaChord
 } from 'teoria'
+
+// Either "composes" raw bach data into bach.json or, when provided an object, validates its structure as bach.json.
+// Main entry point for integrating with core bach ClojureScript library.
+export const compose = source => {
+  if (typeof source === 'string') {
+    return bach(source)
+  }
+
+  if (typeof source === 'object') {
+    return valid(source)
+  }
+
+  throw TypeError(`Unsupported Bach.JSON data type (${typeof source}). Must be a bach.json object or raw bach string.`)
+}
 
 // Creates Bach.JSON beat elements from minimal data.
 // WARN: Now dup'd in rebach
@@ -18,15 +33,11 @@ export const atomize = (kind, value) => ({
 // Consumes bach.json source data and parses/normalizes each beat.
 // Light-weight alternative to using Track constructor.
 export const normalize = source => {
-  if (validate(source)) {
-    return Object.assign({}, source, {
-      data: source.data.map(Beat.from)
-    })
-  }
+  const bach = compose(source)
 
-  console.error(validate.errors)
-
-  throw TypeError('Invalid Bach.JSON data')
+  return Object.assign({}, bach, {
+    data: bach.data.map(Beat.from)
+  })
 }
 
 // Converts a parsed Track's `data` back into its serialized form (vanilla bach.json).

--- a/src/sections.js
+++ b/src/sections.js
@@ -1,11 +1,11 @@
 import { Note } from './note'
-import { valid } from './validate'
+// import { valid } from './validate'
 import { sectionize, normalize, notesIn } from './data'
 
 export class Sections {
 
   constructor (source) {
-    this.source = normalize(valid(source))
+    this.source = normalize(source)
     this.data = sectionize(this.source)
   }
 

--- a/src/sections.js
+++ b/src/sections.js
@@ -1,5 +1,4 @@
 import { Note } from './note'
-// import { valid } from './validate'
 import { sectionize, normalize, notesIn } from './data'
 
 export class Sections {
@@ -38,4 +37,5 @@ export class Sections {
 
     return Object.assign(section, { parts })
   }
+
 }

--- a/src/track.js
+++ b/src/track.js
@@ -1,5 +1,5 @@
 import { Beat } from './elements'
-import { valid } from './validate'
+import { compose } from './data'
 
 // TODO: Possibly rename to Bach, Track will just be a Gig construct
 export class Track {
@@ -7,7 +7,7 @@ export class Track {
   // TODO:
   // constructor ({ source, tempo })
   constructor (source) {
-    this.source = valid(source)
+    this.source = compose(source)
   }
 
   /**

--- a/src/track.js
+++ b/src/track.js
@@ -7,6 +7,7 @@ export class Track {
   // TODO:
   // constructor ({ source, tempo })
   constructor (source) {
+    this.origin = source
     this.source = compose(source)
   }
 


### PR DESCRIPTION
**Changes**
 - :art: Adds new `compose` method that parses raw `bach` text into `bach.json` or validates the provided `bach.json` object.
   - :exclamation: This is now the primary entry point method, in the sense of parsing and interpreting/composing the `bach` data into `bach.json`
   - :tada: Previously, since `bach` is written in Clojure, `bach` track composition could only be done on the JVM, either using Clojure directly or via self-hosted `bach-rest-api` (:money_with_wings:)
 - :shipit: Version `2.3.0`