### PR TITLE
[Refactor] Duration units, linear interpolation  + more

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bach-js",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bach-js",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "description": "Bach music notation library for JS",
   "main": "dist/bundle.js",
   "scripts": {

--- a/src/durations.js
+++ b/src/durations.js
@@ -19,11 +19,6 @@ export class Durations {
     return this.all.flatMap((duration, index) => Array(duration).fill(index))
   }
 
-  get total () {
-    // return this.all.reduce((total, duration) => total + duration, 0)
-    return this.source.headers['total-pulse-beats']
-  }
-
   get shortest () {
     return this.all.sort((left, right) => left - right)[0]
   }
@@ -32,7 +27,10 @@ export class Durations {
     return this.all.sort((left, right) => right- left)[0]
   }
 
-  // TODO: Probably just remove
+  get total () {
+    return this.source.headers['total-pulse-beats']
+  }
+
   get bar () {
     return barsOf(this.source)
   }
@@ -63,6 +61,19 @@ export class Durations {
 
   percentage (duration, is = 'pulse') {
     return this.ratio(duration, is) * 100
+  }
+
+  clamp (duration, { is = 'pulse', min = 0, max } = {}) {
+    const total = max || this.cast(duration, { is, as: 'pulse' })
+
+    return Math.min(total, Math.max(min, duration))
+  }
+
+  interpolate (ratio, { is = 'pulse', min = 0, max } = {}) {
+    const x = this.cast(min || 0, { is, as: 'pulse' })
+    const y = this.cast(max || duration, { is, as: 'pulse' })
+
+    return (x * (1 - ratio)) + (y * ratio)
   }
 
   // TODO: Either replace or improve via inspiration with this:

--- a/src/durations.js
+++ b/src/durations.js
@@ -52,7 +52,7 @@ export class Durations {
     return duration / (this.time[as] / this.time[is])
   }
 
-  unitize (duration, { is = 'pulse', as = 'beat' }) {
+  unitize (duration, { is = 'pulse', as = 'beat' } = {}) {
     return duration / (this.unit[as] / this.unit[is])
   }
 

--- a/src/durations.js
+++ b/src/durations.js
@@ -1,4 +1,4 @@
-import { normalize, unitsOf, barsOf, timesOf, intervalsOf } from './data'
+import { normalize, unitsOf, barsOf, timesOf, intervalsOf, gcd, clamp, lerp } from './data'
 
 export class Durations {
 
@@ -64,16 +64,16 @@ export class Durations {
   }
 
   clamp (duration, { is = 'pulse', min = 0, max } = {}) {
-    const total = max || this.cast(duration, { is, as: 'pulse' })
+    const total = this.cast(duration, { is, as: 'pulse' })
 
-    return Math.min(total, Math.max(min, duration))
+    return clamp(duration, min, max || total)
   }
 
   interpolate (ratio, { is = 'pulse', min = 0, max } = {}) {
     const x = this.cast(min || 0, { is, as: 'pulse' })
     const y = this.cast(max || duration, { is, as: 'pulse' })
 
-    return (x * (1 - ratio)) + (y * ratio)
+    return lerp(ratio, x, y)
   }
 
   // TODO: Either replace or improve via inspiration with this:

--- a/src/durations.js
+++ b/src/durations.js
@@ -1,10 +1,10 @@
-import { normalize, unitsOf, barsOf, timesOf, intervalsOf, gcd, clamp, lerp } from './data'
+import { normalize, unitsOf, barsOf, timesOf, intervalsOf } from './data'
+import { gcd, clamp, lerp } from './math'
 
 export class Durations {
 
   constructor (source) {
     this.source = normalize(source)
-    // this.unit = 'pulse'
   }
 
   get data () {

--- a/src/durations.js
+++ b/src/durations.js
@@ -20,7 +20,8 @@ export class Durations {
   }
 
   get total () {
-    return this.all.reduce((total, duration) => total + duration, 0)
+    // return this.all.reduce((total, duration) => total + duration, 0)
+    return this.source.headers['total-pulse-beats']
   }
 
   get shortest () {

--- a/src/durations.js
+++ b/src/durations.js
@@ -37,6 +37,10 @@ export class Durations {
   }
 
   get unit () {
+    return unitsOf(this.source)
+  }
+
+  get time () {
     return timesOf(this.source)
   }
 
@@ -45,6 +49,10 @@ export class Durations {
   }
 
   cast (duration, { is = 'pulse', as = 'ms' } = {}) {
+    return duration / (this.time[as] / this.time[is])
+  }
+
+  unitize (duration, { is = 'pulse', as = 'beat' }) {
     return duration / (this.unit[as] / this.unit[is])
   }
 

--- a/src/durations.js
+++ b/src/durations.js
@@ -55,6 +55,13 @@ export class Durations {
     return duration / (this.unit[as] / this.unit[is])
   }
 
+  metronize (duration, { is = 'pulse', as = 'beat' }) {
+    const index = this.cast(duration, { is, as })
+    const bar = this.cast(this.bar.pulse, { as })
+
+    return Math.floor(index % bar)
+  }
+
   ratio (duration, is = 'pulse') {
     return this.cast(duration, { is, as: 'pulse' }) / this.total
   }

--- a/src/math.js
+++ b/src/math.js
@@ -1,9 +1,9 @@
 /**
- * Determines the greatest common denominator between two values
+ * Recursively calculates the greatest common denominator (GCD) between two values
  *
- * @param {number} a
- * @param {number} b
- * @returns {number}
+ * @param {Number} a
+ * @param {Number} b
+ * @returns {Number}
  */
 export function gcd (a, b) {
   if (b == 0) {
@@ -16,10 +16,10 @@ export function gcd (a, b) {
 /**
  * Modifies a value so that it is always between the provided min and max
  *
- * @param {number} value
- * @param {number} min
- * @param {number} max
- * @returns {number}
+ * @param {Number} value
+ * @param {Number} min
+ * @param {Number} max
+ * @returns {Number}
  */
 export function clamp (value, min = 0, max = 1) {
   return Math.min(max, Math.max(min, value))
@@ -28,10 +28,10 @@ export function clamp (value, min = 0, max = 1) {
 /**
  * Interpolation function returning the value between x and y at a specific ratio
  *
- * @param {number} value
- * @param {number} min
- * @param {number} max
- * @returns {number}
+ * @param {Number} value
+ * @param {Number} x
+ * @param {Number} y
+ * @returns {Number}
  */
 export function lerp (ratio, x, y) {
   return (x * (1 - ratio)) + (y * ratio)
@@ -40,10 +40,10 @@ export function lerp (ratio, x, y) {
 /**
  * Interpolation function returning the ratio of a value clamped between x and y
  *
- * @param {number} value
- * @param {number} min
- * @param {number} max
- * @returns {number}
+ * @param {Number} value
+ * @param {Number} x
+ * @param {Number} y
+ * @returns {Number}
  */
 
 export function invlerp (value, x, y) {
@@ -53,7 +53,7 @@ export function invlerp (value, x, y) {
 /**
  * Determines the element found in an array at a given ratio
  *
- * @param {float} ratio
+ * @param {Float} ratio
  * @param {Array} all
  */
 export function steps (ratio, all) {

--- a/src/math.js
+++ b/src/math.js
@@ -56,7 +56,7 @@ export function invlerp (value, x, y) {
  * @param {float} ratio
  * @param {Array} all
  */
-export function steps (ratio, all) => {
+export function steps (ratio, all) {
   ratio %= 1
 
   if (ratio < 0) ratio += 1

--- a/src/math.js
+++ b/src/math.js
@@ -1,0 +1,65 @@
+/**
+ * Determines the greatest common denominator between two values
+ *
+ * @param {number} a
+ * @param {number} b
+ * @returns {number}
+ */
+export function gcd (a, b) {
+  if (b == 0) {
+    return a
+  }
+
+  return gcd(b, a % b)
+}
+
+/**
+ * Modifies a value so that it is always between the provided min and max
+ *
+ * @param {number} value
+ * @param {number} min
+ * @param {number} max
+ * @returns {number}
+ */
+export function clamp (value, min = 0, max = 1) {
+  return Math.min(max, Math.max(min, value))
+}
+
+/**
+ * Interpolation function returning the value between x and y at a specific ratio
+ *
+ * @param {number} value
+ * @param {number} min
+ * @param {number} max
+ * @returns {number}
+ */
+export function lerp (ratio, x, y) {
+  return (x * (1 - ratio)) + (y * ratio)
+}
+
+/**
+ * Interpolation function returning the ratio of a value clamped between x and y
+ *
+ * @param {number} value
+ * @param {number} min
+ * @param {number} max
+ * @returns {number}
+ */
+
+export function invlerp (value, x, y) {
+  return clamp((value - x) / (y - x))
+}
+
+/**
+ * Determines the element found in an array at a given ratio
+ *
+ * @param {float} ratio
+ * @param {Array} all
+ */
+export function steps (ratio, all) => {
+  ratio %= 1
+
+  if (ratio < 0) ratio += 1
+
+  return all[Math.floor(ratio * all.length)]
+}

--- a/src/track.js
+++ b/src/track.js
@@ -1,4 +1,5 @@
 import { Beat } from './elements'
+import { Durations } from './durations'
 import { compose } from './data'
 
 // TODO: Possibly rename to Bach, Track will just be a Gig construct
@@ -106,6 +107,10 @@ export class Track {
     const beats = this.data.reduce((acc, measure) => acc + measure.length, 0)
 
     return { measures, beats }
+  }
+
+  get durations () {
+    return new Durations(this.source)
   }
 
   /**

--- a/src/track.js
+++ b/src/track.js
@@ -109,6 +109,11 @@ export class Track {
     return { measures, beats }
   }
 
+  /**
+   * Provides a usable duration-specific API that can convert between units and more.
+   *
+   * @returns {Durations}
+   */
   get durations () {
     return new Durations(this.source)
   }


### PR DESCRIPTION
**Changes**
 - :recycle: Refactored `Durations.cast` by re-introducing `Durations.untiize`.
   * `cast` works with milliseconds as its base unit and can suffer from natural floating point precision loss in certain cases
   * `unitize` works with `pulse-beat` as its base unit and will suffers much less from precision loss (only with unusually small pulse-beat units)
 - :straight_ruler: Added several generic linear interpolation methods (`math` module) and integrated into `Durations` class
   * :clock1: It's now much more trivial to convert between duration units in reference to time
   * :link: Reference: https://www.trysmudford.com/blog/linear-interpolation-functions/
 - :shipit: Version `2.5.0`

**Future**
 - :scroll: Documentation (next up)
 - :microscope: Tests (next up)